### PR TITLE
数据的表示从 stdObject 改为关联数组

### DIFF
--- a/bin/render.php
+++ b/bin/render.php
@@ -26,5 +26,5 @@ function getData($caseDir) {
         return data();
     }
     $dataStr = file_get_contents($caseDir . "/data.json");
-    return json_decode($dataStr);
+    return json_decode($dataStr, true);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "san-ssr-target-php",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/runtime/san.php
+++ b/runtime/san.php
@@ -16,31 +16,19 @@ class SanSSRData {
         }
         $seq = $this->parseExpr($path);
         $val = $this->data;
-        foreach ($seq as $name) {
-            if (isset($val->$name)) {
-                $val = $val->$name;
-            }
-            else {
-                return null;
-            }
-        }
+        foreach ($seq as $name) $val = $val[$name];
         return $val;
     }
 
     public function set ($path, $val) {
         $seq = $this->parseExpr($path);
-        $parent = $this->data;
+        $parent = &$this->data;
         for ($i = 0; $i < count($seq) - 1; $i++) {
             $name = $seq[$i];
-            if (isset($parent->$name)) {
-                $parent = $parent->$name;
-            }
-            else {
-                return null;
-            }
+            $parent = &$parent[$name];
         }
         $key = end($seq);
-        $parent->$key = $val;
+        $parent[$key] = $val;
         return $val;
     }
 

--- a/runtime/underscore.php
+++ b/runtime/underscore.php
@@ -4,6 +4,7 @@ final class _
     public static $HTML_ENTITY;
     public static $BASE_PROPS;
   
+    // TODO make it compile time
     public static function data($ctx, $seq = []) {
         $data = $ctx->data;
         foreach ($seq as $name) {
@@ -26,26 +27,28 @@ final class _
 
       $initData = $inst->initData();
       foreach ($initData as $key => $val) {
-          if (isset($data->$key)) continue;
-          $data->$key = $val;
+          if (isset($data["$key"])) continue;
+          $data["$key"] = $val;
       }
       return $data;
     }
 
+    // TODO make it compile time
     public static function objSpread($arr, $needSpread) {
-        $obj = (object)[];
+        $obj = [];
         foreach ($arr as $idx => $val) {
             if ($needSpread[$idx]) {
                 foreach ($val as $subkey => $subvar) {
-                    $obj->{$subkey} = $subvar;
+                    $obj["$subkey"] = $subvar;
                 }
             } else {
-                $obj->{$val[0]} = $val[1];
+                $obj["$val[0]"] = $val[1];
             }
         }
         return $obj;
     }
 
+    // TODO make it compile time
     public static function spread($arr, $needSpread) {
         $ret = [];
         foreach ($arr as $idx => $val) {
@@ -58,12 +61,11 @@ final class _
         return $ret;
     }
 
-    public static function extend($target, $source)
+    public static function extend(&$target, $source)
     {
-        if (!$target) $target = (object)[];
         if ($source) {
             foreach ($source as $key => $val) {
-                $target->{$key} = $val;
+                $target["$key"] = $val;
             }
         }
         return $target;
@@ -122,8 +124,17 @@ final class _
         return htmlspecialchars($str, ENT_QUOTES);
     }
 
-    public static function json_encode ($obj) {
-        return json_encode($obj, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    public static function json_encode ($obj, $flag = 0) {
+        return json_encode($obj, $flag | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    public static function log () {
+        $numargs = func_num_args();
+        $arg_list = func_get_args();
+        for ($i = 0; $i < $numargs; $i++) {
+            echo _::json_encode($arg_list[$i], JSON_PRETTY_PRINT) . ' ';
+        }
+        echo "\n";
     }
 
     public static function _classFilter($source)

--- a/src/compilers/anode-compiler.ts
+++ b/src/compilers/anode-compiler.ts
@@ -107,11 +107,11 @@ export class ANodeCompiler {
         const indexName = forDirective.index || this.nextID()
         const listName = this.nextID()
 
-        emitter.writeLine('$' + listName + ' = ' + compileExprSource.expr(forDirective.value) + ';')
+        emitter.writeLine(`$${listName} = ${compileExprSource.expr(forDirective.value)};`)
         emitter.writeIf(`is_array($${listName}) || is_object($${listName})`, () => {
             emitter.writeForeach(`$${listName} as $${indexName} => $value`, () => {
-                emitter.writeLine(`$ctx->data->${indexName} = $${indexName};`)
-                emitter.writeLine(`$ctx->data->${itemName} = $value;`)
+                emitter.writeLine(`$ctx->data["${indexName}"] = $${indexName};`)
+                emitter.writeLine(`$ctx->data["${itemName}"] = $value;`)
                 this.compile(forElementANode, emitter)
             })
         })
@@ -169,7 +169,7 @@ export class ANodeCompiler {
 
                     for (const varItem of aNode.vars || []) {
                         emitter.writeLine(
-                            '$slotCtx->data->' + varItem.name + ' = ' +
+                            `$slotCtx->data["${varItem.name}"] = ` +
                             compileExprSource.expr(varItem.expr) + ';'
                         )
                     }
@@ -192,7 +192,7 @@ export class ANodeCompiler {
     }
 
     compileComponent (aNode: ANode, emitter: PHPEmitter, info: ComponentInfo) {
-        let dataLiteral = '(object)[]'
+        let dataLiteral = '[]'
 
         emitter.writeLine('$sourceSlots = [];')
         if (aNode.children) {
@@ -244,7 +244,7 @@ export class ANodeCompiler {
             givenData.push(`${key} => ${val}`)
         }
 
-        dataLiteral = '(object)[' + givenData.join(',\n') + ']'
+        dataLiteral = '[' + givenData.join(',\n') + ']'
         if (aNode.directives.bind) {
             dataLiteral = '_::extend(' +
             compileExprSource.expr(aNode.directives.bind.value) +

--- a/src/compilers/anode-compiler.ts
+++ b/src/compilers/anode-compiler.ts
@@ -246,11 +246,9 @@ export class ANodeCompiler {
 
         dataLiteral = '[' + givenData.join(',\n') + ']'
         if (aNode.directives.bind) {
-            dataLiteral = '_::extend(' +
-            compileExprSource.expr(aNode.directives.bind.value) +
-            ', ' +
-            dataLiteral +
-            ')'
+            const bindData = compileExprSource.expr(aNode.directives.bind.value)
+            emitter.writeLine(`$childData = ${bindData};`)
+            dataLiteral = `_::extend($childData, ${dataLiteral})`
         }
 
         const renderId = 'sanssrRenderer' + info.cid

--- a/src/compilers/stringifier.ts
+++ b/src/compilers/stringifier.ts
@@ -9,7 +9,7 @@ export class Stringifier {
 
     obj (source: object) {
         let prefixComma
-        let result = '(object)['
+        let result = '['
 
         for (const key in source) {
             if (!source.hasOwnProperty(key) || typeof source[key] === 'undefined') {

--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -43,7 +43,7 @@ export class PHPEmitter extends Emitter {
     }
 
     public writeDataComment () {
-        this.writeHTML('"<!--s-data:" . json_encode(' + dataAccess() + ', JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "-->";')
+        this.writeHTML(`"<!--s-data:" . _::json_encode(${dataAccess()}) . "-->"`)
     }
 
     public clearStringLiteralBuffer () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export default class ToPHPCompiler implements Compiler {
         for (const componentInfo of sanApp.componentTree.preOrder()) {
             const { cid } = componentInfo
             const funcName = 'sanssrRenderer' + cid
-            emitter.writeFunction(funcName, ['$data', '$noDataOutput = false', '$parentCtx = []', '$tagName = null', '$sourceSlots = []'], [], () => {
+            emitter.writeFunction(funcName, ['$data = []', '$noDataOutput = false', '$parentCtx = []', '$tagName = null', '$sourceSlots = []'], [], () => {
                 const rc = new RendererCompiler(sanApp.componentTree, noTemplateOutput, nsPrefix)
                 rc.compile(componentInfo, emitter)
             })

--- a/test/cases/bool-attr-bindings-false/expected.html
+++ b/test/cases/bool-attr-bindings-false/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><button>button</button></div>
+<div><!--s-data:[]--><button>button</button></div>

--- a/test/cases/bool-attr-init-false/expected.html
+++ b/test/cases/bool-attr-init-false/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><button>button</button></div>
+<div><!--s-data:[]--><button>button</button></div>

--- a/test/cases/bool-attr-no-binding/expected.html
+++ b/test/cases/bool-attr-no-binding/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><button disabled>button</button></div>
+<div><!--s-data:[]--><button disabled>button</button></div>

--- a/test/cases/data-binding-no-expr/expected.html
+++ b/test/cases/data-binding-no-expr/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><a><u></u></a></div>
+<div><!--s-data:[]--><a><u></u></a></div>

--- a/test/cases/date-data/data.php
+++ b/test/cases/date-data/data.php
@@ -2,7 +2,7 @@
 require_once(__DIR__ . '/../../../runtime/Ts2Php_Helper.php');
 
 function data() {
-    return (object)[
+    return [
         "date" => new Ts2Php_Date(Ts2Php_Date::parse("1983-09-02T16:00:00.000Z"))
     ];
 }

--- a/test/cases/depend-on-declaration/expected.html
+++ b/test/cases/depend-on-declaration/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><b>a &lt; b</b></div>
+<div><!--s-data:[]--><b>a &lt; b</b></div>

--- a/test/cases/elif-update-all-false/expected.html
+++ b/test/cases/elif-update-all-false/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--></div>
+<div><!--s-data:[]--></div>

--- a/test/cases/given-undefined-dont-reset/component.js
+++ b/test/cases/given-undefined-dont-reset/component.js
@@ -17,7 +17,7 @@ const MyComponent = san.defineComponent({
     },
     initData: function () {
         return {
-            formData: {}
+            formData: {bar: 'bar'}
         }
     },
     getFooValue: function () {

--- a/test/cases/given-undefined-dont-reset/expected.html
+++ b/test/cases/given-undefined-dont-reset/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{"formData":{}}--><u>foo</u></div>
+<div><!--s-data:{"formData":{"bar": "bar"}}--><u>foo</u></div>

--- a/test/cases/html-entity/expected.html
+++ b/test/cases/html-entity/expected.html
@@ -1,1 +1,1 @@
-<u><!--s-data:{}-->&#39;&#x00021;&emsp;&ensp;&thinsp;&copy;&lt;p&gt;&reg;&lt;/p&gt;&reg;&zwnj;&zwj;&lt;&nbsp;&gt;&quot;</u>
+<u><!--s-data:[]-->&#39;&#x00021;&emsp;&ensp;&thinsp;&copy;&lt;p&gt;&reg;&lt;/p&gt;&reg;&zwnj;&zwj;&lt;&nbsp;&gt;&quot;</u>

--- a/test/cases/html-expr/expected.html
+++ b/test/cases/html-expr/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--><!--s-text-->13<!--/s-text--></div>
+<div><!--s-data:[]--><!--s-text-->13<!--/s-text--></div>

--- a/test/cases/plain-span-notpl/expected.html
+++ b/test/cases/plain-span-notpl/expected.html
@@ -1,1 +1,1 @@
-<!--s-data:{}--><span>should be top</span>this too
+<!--s-data:[]--><span>should be top</span>this too

--- a/test/cases/root-with-if/expected.html
+++ b/test/cases/root-with-if/expected.html
@@ -1,1 +1,1 @@
-<div><!--s-data:{}--></div>
+<div><!--s-data:[]--></div>

--- a/test/unit/compilers/stringifier.spec.ts
+++ b/test/unit/compilers/stringifier.spec.ts
@@ -37,7 +37,7 @@ describe('Stringifier', function () {
             b: 2
         }
         const ret = stringifier.any(obj)
-        expect(ret).toEqual('(object)["a" => 1,"b" => 2]')
+        expect(ret).toEqual('["a" => 1,"b" => 2]')
     })
 
     it('should stringify object and skip undefined value', function () {
@@ -48,7 +48,7 @@ describe('Stringifier', function () {
         }
 
         const ret = stringifier.any(obj)
-        expect(ret).toEqual('(object)["a" => 1,"b" => 2]')
+        expect(ret).toEqual('["a" => 1,"b" => 2]')
     })
 
     it('should stringify array', function () {

--- a/test/unit/emitters/emitter.spec.ts
+++ b/test/unit/emitters/emitter.spec.ts
@@ -23,7 +23,7 @@ describe('PHPEmitter', function () {
     it('should write data comment', function () {
         emitter.writeDataComment()
 
-        expect(emitter.fullText()).toEqual('$html .= "<!--s-data:" . json_encode(_::data($ctx, []), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "-->";;\n')
+        expect(emitter.fullText()).toEqual('$html .= "<!--s-data:" . _::json_encode(_::data($ctx, [])) . "-->";\n')
     })
 
     describe('write namespace', function () {

--- a/test/unit/underscore.spec.php
+++ b/test/unit/underscore.spec.php
@@ -7,11 +7,11 @@ final class _Test extends TestCase
 {
     public function testExtend(): void
     {
-        $target = (object)["foo" => "FOO", "bar" => "BAR"];
-        $source = (object)["bar" => "bar", "coo" => "COO"];
+        $target = ["foo" => "FOO", "bar" => "BAR"];
+        $source = ["bar" => "bar", "coo" => "COO"];
         _::extend($target, $source);
 
-        $this->assertEquals((object)[
+        $this->assertEquals([
             "foo" => "FOO",
             "bar" => "bar",
             "coo" => "COO"


### PR DESCRIPTION
解决问题：

1. ts2php 中 object literal 翻译为关联数组，这部分数据用 stdObject 方式去读写会 FATAL
2. 既有的 smarty 数据为关联数组，这部分数据用 stdObject 方式去读写会 FATAL

引入问题：

1. TypeScript 空对象 -> PHP 空关联数组 -> json_encode -> JavaScript 空数组（也就是说空对象会 ssr 后会变成空数组）。反解时可能有问题。

考虑模板数据应该关联数组语义上更符合，且 Object 是 Array 的父类，如果 Array is a Object 满足那应该不会引入问题。需要注意反解时判断是否是 Array 的地方。